### PR TITLE
Add match_origin_as_fallback:true to match data:

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
     "js": ["contentscript.js"],
     "run_at": "document_start",
     "match_about_blank": true,
+    "match_origin_as_fallback": true,
     "matches": ["<all_urls>"]
   }],
 


### PR DESCRIPTION
When Quitter was migrated to a WebExtension, a special change had to be made in Firefox to make sure that the extension continued to run on data:-URLs, in https://bugzilla.mozilla.org/show_bug.cgi?id=1451463

As of Firefox 128, the standard match_origin_as_fallback property serves this purpose (of matching data:-URLs) and we should use this instead. This would enable us to drop the undocumented top-level data: special case that was added in bug 1451463, which is tracked at https://bugzilla.mozilla.org/show_bug.cgi?id=1902635